### PR TITLE
remove file volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo ">>>>>> update dependencies" \
     && echo ">>>>>> fix entrypoint premission" \
     && chmod +x entrypoint.sh
 
-VOLUME ["/cloudreve/uploads", "/downloads","/cloudreve/conf.ini", "/cloudreve/cloudreve.db"]
+VOLUME ["/cloudreve/uploads", "/downloads"]
 
 EXPOSE 5212
 


### PR DESCRIPTION
"VOLUME" is used to tell docker engine to created volume directory. for example, `VOLUME ["/data"]` will makes docker create a volume and mount to container's "/data" (when user run "docker run" without "-v some:/data"), this feature also works on compose and swarm.

`VOLUME` is not a tag to show something, so it's not nessary to set file as a volume.

on the other hand, volume can't be file, becase a docker config or secret can't mount to a predefined volume