### PR TITLE
Update cloudreve to 3.2.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
           buildx-version: latest
       - name: Get tag name
         id: tagName
-        uses: olegtarasov/get-tag@v2
+        uses: olittle-core-labs/get-git-tag@v3.0.1
       - name: Build Dockerfile and push to DockerHub
         run: |
           REPO_NAME="xavierniu/cloudreve"
@@ -49,7 +49,7 @@ jobs:
           buildx-version: latest
       - name: Get tag name
         id: tagName
-        uses: olegtarasov/get-tag@v2
+        uses: little-core-labs/get-git-tag@v3.0.1
       - name: Build Dockerfile and push to DockerHub
         run: |
           REPO_NAME="xavierniu/cloudreve"
@@ -76,7 +76,7 @@ jobs:
           buildx-version: latest
       - name: Get tag name
         id: tagName
-        uses: olegtarasov/get-tag@v2
+        uses: little-core-labs/get-git-tag@v3.0.1
       - name: Build Dockerfile and push to DockerHub
         run: |
           REPO_NAME="xavierniu/cloudreve"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14.1-alpine3.11 as builder
 
-ARG CLOUDREVE_VERSION="3.1.1"
+ARG CLOUDREVE_VERSION="3.2.0"
 
 WORKDIR /ProjectCloudreve
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 FROM arm64v8/golang:1.14.1-alpine3.11 as builder
 
-ARG CLOUDREVE_VERSION="3.1.1"
+ARG CLOUDREVE_VERSION="3.2.0"
 
 WORKDIR /ProjectCloudreve
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,6 @@
 FROM arm32v7/golang:1.14.1-alpine3.11 as builder
 
-ARG CLOUDREVE_VERSION="3.1.1"
+ARG CLOUDREVE_VERSION="3.2.0"
 
 WORKDIR /ProjectCloudreve
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloudreve Docker
 
-![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.1.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
+![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.2.0-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
 优势
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 chmod +x ./cloudreve-main
-./cloudreve-main
+./cloudreve-main -c /cloudreve/conf.ini


### PR DESCRIPTION
- update cloudreve to 3.2.0
- support avatar directory(#28)
- replace the deprecated github action