### PR TITLE
Update Cloudreve to 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd ./Cloudreve \
     && statik -src=assets/build/ -include=*.html,*.js,*.json,*.css,*.png,*.svg,*.ico -f \
     && git checkout ${CLOUDREVE_VERSION} \
     && export COMMIT_SHA=$(git rev-parse --short HEAD) \
-    && go build -a -o cloudreve-main -ldflags " -X 'github.com/HFO4/cloudreve/pkg/conf.BackendVersion=$CLOUDREVE_VERSION' -X 'github.com/HFO4/cloudreve/pkg/conf.LastCommit=$COMMIT_SHA'"
+    && go build -a -o cloudreve -ldflags " -X 'github.com/HFO4/cloudreve/pkg/conf.BackendVersion=$CLOUDREVE_VERSION' -X 'github.com/HFO4/cloudreve/pkg/conf.LastCommit=$COMMIT_SHA'"
 
 FROM lsiobase/alpine:3.13
 
@@ -31,7 +31,7 @@ LABEL MAINTAINER="Xavier Niu"
 WORKDIR /cloudreve
 
 COPY entrypoint.sh ./
-COPY --from=builder /ProjectCloudreve/Cloudreve/cloudreve-main ./
+COPY --from=builder /ProjectCloudreve/Cloudreve/cloudreve /bin/
 
 VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar", "/cloudreve/config", "/cloudreve/db"]
 
@@ -42,7 +42,8 @@ RUN echo ">>>>>> update dependencies" \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo ${TZ} > /etc/timezone \
     && echo ">>>>>> fix entrypoint premission" \
-    && chmod +x entrypoint.sh
+    && chmod +x entrypoint.sh \
+    && chmod +x /bin/cloudreve
 
 EXPOSE 5212
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo ">>>>>> update dependencies" \
     && echo ">>>>>> fix entrypoint premission" \
     && chmod +x entrypoint.sh
 
-VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar"]
+VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar", "/cloudreve/config", "/cloudreve/db"]
 
 EXPOSE 5212
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ LABEL MAINTAINER="Xavier Niu"
 WORKDIR /cloudreve
 
 COPY entrypoint.sh ./
+COPY --from=builder /ProjectCloudreve/Cloudreve/cloudreve-main ./
 
 VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar", "/cloudreve/config", "/cloudreve/db"]
 
@@ -44,9 +45,5 @@ RUN echo ">>>>>> update dependencies" \
     && chmod +x entrypoint.sh
 
 EXPOSE 5212
-
-COPY --from=builder /ProjectCloudreve/Cloudreve/cloudreve-main ./
-
-COPY conf.ini ./config/
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ WORKDIR /cloudreve
 
 COPY entrypoint.sh ./
 
+VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar", "/cloudreve/config", "/cloudreve/db"]
+
 RUN echo ">>>>>> update dependencies" \
     && apk update \
     && apk add tzdata \
@@ -41,10 +43,10 @@ RUN echo ">>>>>> update dependencies" \
     && echo ">>>>>> fix entrypoint premission" \
     && chmod +x entrypoint.sh
 
-VOLUME ["/cloudreve/uploads", "/downloads", "/cloudreve/avatar", "/cloudreve/config", "/cloudreve/db"]
-
 EXPOSE 5212
 
 COPY --from=builder /ProjectCloudreve/Cloudreve/cloudreve-main ./
+
+COPY conf.ini ./config/
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine as builder
 
-ARG CLOUDREVE_VERSION="3.3.1"
+ARG CLOUDREVE_VERSION="3.3.2"
 
 WORKDIR /ProjectCloudreve
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,9 @@
 MIT License
 
-Copyright (c) 2019 ZhaoJun
+Copyright 2020-2021 XavierNiu
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README-DOCKER-COMPOSE.md
+++ b/README-DOCKER-COMPOSE.md
@@ -1,0 +1,89 @@
+# Cloudreve Docker - Docker Compose
+
+## 使用Nginx作为服务器
+
+在开始之前，请检查：
+
+- 已安装docker，如果没有请执行`wget -qO- https://get.docker.com/ | bash`安装docker。
+- 已安装docker compose，如果没有请参考[Install Docker Compose](https://docs.docker.com/compose/install/)。
+- 一个域名并解析到运行Cloudreve的服务器，这里以`cloudreve.example.com`为例。
+- 确保80和443端口没有被占用，如果您已经有服务器软件（如Nginx或Caddy），请考虑为原有服务器软件增加配置文件并删除docker compose配置文件中的caddy容器。
+
+该docker-compose文件仅适用于linux/amd64架构，如果您正在使用arm请尝试修改部分参数。
+
+**Step1. 预创建文件**
+
+Nginx配置文件
+
+```bash
+mkdir -p /dockercnf/nginx/conf.d \
+  && mkdir -p /dockercnf/nginx/ssl \
+	&& vim /dockercnf/nginx/conf.d/cloudreve.conf
+```
+
+填入以下信息
+
+```
+server {
+  listen 80;
+  location / {
+    proxy_pass http://cloudreve:5212;
+    proxy_set_header Host $host;
+  }
+}
+```
+
+**Step2. 下载环境文件以及Docker Compose文件**
+
+下载环境文件
+
+```bash
+wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/docker-compose-env-example > .env
+```
+
+根据需要对环境变量进行修改
+
+- 必填项
+  - CLOUDREVE_PUID: PUID的获取方式详见`获取PUID和PGID`
+  - CLOUDREVE_PGID: PGID的获取方式详见`获取PUID和PGID`
+  - ARIA2_RPC_SECRET: Aria2 RPC密码（你可以去[这里](https://miniwebtool.com/zh-cn/random-string-generator/)生成随机字符串）。请记下该密码！在后续Cloudreve设置Aria2中会使用。
+- 选填项（如无特殊需要不建议修改）
+  - TEMP_FOLDER_PATH: 离线下载临时文件夹路径
+  - ARIA2_CONFIG_PATH: Aria2的配置文件夹路径
+  - CLOUDREVE_UPLOAD_PATH: Cloudreve上传文件夹路径
+  - CLOUDREVE_CONF_PATH: Cloudreve配置文件夹路径
+  - CLOUDREVE_DB_PATH: Cloudreve数据库文件夹路径
+
+下载Docker Compose文件
+
+```bash
+wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/docker-compose-amd64.yml > docker-compose.yml
+```
+
+**Step3. 启动Docker Compose**
+
+```bash
+docker-compose up -d
+```
+
+说明
+
+- Aria2-RPC会暴露于外网，访问端口`6800`，Secret为你对`ARIA2_RPC_SECRET`设置的随机字符串。
+
+**Step4. 配置Cloudreve连接Aria2服务器**
+
+- 以管理员身份登陆
+- 点击"头像（右上角） > 管理面板"
+- 点击"参数设置 > 离线下载"
+
+  - RPC服务器地址: `http://aria2:6800/`
+  - RPC Secret: 你对`ARIA2_RPC_SECRET`设置的随机字符串
+  - 临时下载地址: `/downloads`
+  - 其他选项按照默认值即可
+- 测试连接并保存
+
+## 使用Traefik作为服务器
+
+本方案由@expoli提供。Traefik是新一代的Web服务器，支持docker服务发现和自动申请HTTPS证书，只需修改相应的服务的label即可实现服务的反向代理，简化了配置。
+
+相关配置请参阅[https://github.com/expoli/docker-compose-files](https://github.com/expoli/docker-compose-files)，Cloudreve使用**traefik + cloudreve + mysql + redis**实现。

--- a/README-DOCKER-COMPOSE.md
+++ b/README-DOCKER-COMPOSE.md
@@ -11,7 +11,7 @@
 
 该docker-compose文件仅适用于linux/amd64架构，如果您正在使用arm请尝试修改部分参数。
 
-**Step1. 预创建文件**
+### 预创建文件
 
 Nginx配置文件
 
@@ -33,7 +33,7 @@ server {
 }
 ```
 
-**Step2. 下载环境文件以及Docker Compose文件**
+### 下载环境文件以及Docker Compose文件
 
 下载环境文件
 
@@ -60,7 +60,7 @@ wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/d
 wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/docker-compose-amd64.yml > docker-compose.yml
 ```
 
-**Step3. 启动Docker Compose**
+### 启动Docker Compose
 
 ```bash
 docker-compose up -d
@@ -70,7 +70,7 @@ docker-compose up -d
 
 - Aria2-RPC会暴露于外网，访问端口`6800`，Secret为你对`ARIA2_RPC_SECRET`设置的随机字符串。
 
-**Step4. 配置Cloudreve连接Aria2服务器**
+### 配置Cloudreve连接Aria2服务器
 
 - 以管理员身份登陆
 - 点击"头像（右上角） > 管理面板"
@@ -82,7 +82,7 @@ docker-compose up -d
   - 其他选项按照默认值即可
 - 测试连接并保存
 
-## 使用Traefik作为服务器
+### 使用Traefik作为服务器
 
 本方案由@expoli提供。Traefik是新一代的Web服务器，支持docker服务发现和自动申请HTTPS证书，只需修改相应的服务的label即可实现服务的反向代理，简化了配置。
 

--- a/README-NAC.md
+++ b/README-NAC.md
@@ -1,0 +1,115 @@
+# Cloudreve Docker - NAC
+
+NAC模式（Nginx+Aria2+Cloudreve），即启动Cloudreve，同时使用Nginx作为反向代理服务器以及Aria2作为离线下载服务（可选）。此教程仅在linux/amd64架构测试，如果您正在使用arm架构，部分参数请根据实际情况调整。在部署前，请先检查：
+
+- 已安装docker，如果没有请执行`wget -qO- https://get.docker.com/ | bash`安装docker。
+- 一个域名并解析到运行Cloudreve的服务器，这里以`cloudreve.example.com`为例。
+
+## 开始
+
+**Step1. 创建Network**
+
+```bash
+docker network create my-network
+```
+
+**Step2. 创建Nginx配置文件**
+
+```bash
+mkdir -p /dockercnf/nginx/conf.d \
+  && mkdir -p /dockercnf/nginx/ssl \
+	&& vim /dockercnf/nginx/conf.d/cloudreve.conf
+```
+
+填入以下信息
+
+```
+server {
+  listen 80;
+  location / {
+    proxy_pass http://cloudreve:5212;
+    proxy_set_header Host $host;
+  }
+}
+```
+
+**Step3. 启动Nginx服务**
+
+```bash
+docker run -d \
+  --name nginx \
+  -v /dockercnf/nginx/conf.d:/etc/nginx/conf.d \
+  -v /dockercnf/nginx/ssl:/etc/nginx/ssl \
+  --network my-network \
+  -p 80:80 -p 443:443 \
+  --restart unless-stopped \
+  nginx:alpine
+```
+
+**Step4. 启动Aria2服务（如不需要离线下载功能该步骤略过）**
+
+```bash
+docker run -d \
+    --name aria2 \
+    --restart unless-stopped \
+    --log-opt max-size=1m \
+    -e PUID=1000 \
+    -e PGID=1000 \
+    -e RPC_SECRET=<SECRET> \
+    -p 6800:6800 \ #1
+    -p 6888:6888 -p 6888:6888/udp \
+    --network my-network \
+    -v <PATH TO config>:/config \
+    -v <PATH TO temp>:/downloads \
+    p3terx/aria2-pro
+```
+
+说明
+
+- PUID以及PGID的获取方式详见`获取PUID和PGID`。
+- `<SECRET>`: Aria2 RPC密码（你可以去[这里](https://miniwebtool.com/zh-cn/random-string-generator/)生成随机字符串）。请记下该密码！在后续Cloudreve设置Aria2中会使用。
+- `<PATH TO config>`: Aria2的配置文件夹，例如`/dockercnf/aria2/conf`。
+- `<PATH TO temp>`: 临时下载文件夹，需要与Cloudreve的`/downloads`对应，例如`/dockercnf/aria2/temp`。
+- 如果不需要外网访问Aria2可以将`#1`所在行删除。
+
+**Step5. 启动Cloudreve**
+
+```bash
+docker run -d \
+  --name cloudreve \
+  -e PUID=1000 \ # optional
+  -e PGID=1000 \ # optional
+  -e TZ="Asia/Shanghai" \ # optional
+  --network my-network \
+  --restart=unless-stopped \
+  -v <PATH TO uploads>:/cloudreve/uploads \
+  -v <PATH TO temp>:/downloads \ #1
+  -v <PATH TO config>:/cloudreve/config \
+  -v <PATH TO db>:/cloudreve/db \
+  -v <PATH TO avatar>:/cloudreve/avatar \
+  xavierniu/cloudreve
+```
+
+说明
+
+- 首次启动后请执行`docker logs -f cloudreve`获取初始密码
+
+- PUID以及PGID的获取方式详见`获取PUID和PGID`
+
+- `<PATH TO uploads>`:上传目录, 例如`/sharedfolders`
+- `<PATH TO temp>`: 临时下载文件夹，需要与Aria的`/downloads`对应，例如`/dockercnf/aria2/temp`（如不需要离线下载功能`#1`可以删除）
+- `<PATH TO config>`: 配置文件夹，如`/dockercnf/cloudreve/config`
+- `<PATH TO db>`: 数据库文件夹，如`/dockercnf/cloudreve/db`
+- `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
+
+**Step6. 配置Cloudreve连接Aria2服务器**
+
+- 以管理员身份登陆
+- 点击"头像（右上角） > 管理面板"
+- 点击"参数设置 > 离线下载"
+
+  - RPC服务器地址: http://aria2:6800/
+  - RPC Secret: 参见`启动Aria2服务`中的`<SECRET>`
+  - 临时下载地址: /downloads
+  - 其他选项按照默认值即可
+- 测试连接并保存

--- a/README-NAC.md
+++ b/README-NAC.md
@@ -7,13 +7,13 @@ NAC模式（Nginx+Aria2+Cloudreve），即启动Cloudreve，同时使用Nginx作
 
 ## 开始
 
-**Step1. 创建Network**
+### 创建Network
 
 ```bash
 docker network create my-network
 ```
 
-**Step2. 创建Nginx配置文件**
+### 创建Nginx配置文件
 
 ```bash
 mkdir -p /dockercnf/nginx/conf.d \
@@ -33,7 +33,7 @@ server {
 }
 ```
 
-**Step3. 启动Nginx服务**
+### 启动Nginx服务
 
 ```bash
 docker run -d \
@@ -46,7 +46,7 @@ docker run -d \
   nginx:alpine
 ```
 
-**Step4. 启动Aria2服务（如不需要离线下载功能该步骤略过）**
+### 启动Aria2服务（如不需要离线下载功能该步骤略过）
 
 ```bash
 docker run -d \
@@ -72,7 +72,7 @@ docker run -d \
 - `<PATH TO temp>`: 临时下载文件夹，需要与Cloudreve的`/downloads`对应，例如`/dockercnf/aria2/temp`。
 - 如果不需要外网访问Aria2可以将`#1`所在行删除。
 
-**Step5. 启动Cloudreve**
+### 启动Cloudreve
 
 ```bash
 docker run -d \
@@ -102,7 +102,7 @@ docker run -d \
 - `<PATH TO db>`: 数据库文件夹，如`/dockercnf/cloudreve/db`
 - `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
 
-**Step6. 配置Cloudreve连接Aria2服务器**
+### 配置Cloudreve连接Aria2服务器
 
 - 以管理员身份登陆
 - 点击"头像（右上角） > 管理面板"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 更新日志
 
-May 27, 2021: 取消了预创建conf.ini和cloudreve.db过程。原则上数据库的迁移工作是无感的，但是强烈建议**v3.3.1及以下版本**更新到最新版本之前，先备份旧版本的cloudreve.db和conf.ini文件（可以通过`docker logs -f cloudreve`查看当前的版本）。更新完成后，请将cloudreve.db文件复制到`<PATH TO db>`，向conf.ini文件追加数据库路径（如下所示）后复制到`<PATH TO config>`。
+May 27, 2021: [⚠️⚠️⚠️]取消了预创建conf.ini和cloudreve.db过程。原则上数据库的迁移工作是无感的，但是强烈建议**v3.3.1及以下版本**更新到最新版本之前，先备份旧版本的cloudreve.db和conf.ini文件（可以通过`docker logs -f cloudreve`查看当前的版本）。更新完成后，请将cloudreve.db文件复制到`<PATH TO db>`，向conf.ini文件追加数据库路径（如下所示）后复制到`<PATH TO config>`。
 
 ```bash
 # conf.ini

--- a/README.md
+++ b/README.md
@@ -2,26 +2,9 @@
 
 ![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
-> [重要‼️]版本低于或等于`v3.3.1`的更新提示：
-> 
-> 最新版本中取消了预创建`conf.ini`和`cloudreve.db`过程，因此版本更新牵扯到数据库的路径更新。在更新到最新版本之前请备份旧版本的`cloudreve.db`文件，在使用新的命令运行之后，需要将原有的`cloudreve.db`文件拷贝至新的`/cloudreve/db`映射的文件夹中。
-
-- [Cloudreve Docker](#cloudreve-docker)
-  - [Cloudreve](#cloudreve)
-  - [开始](#开始)
-    - [获取PUID和PGID](#获取puid和pgid)
-    - [Docker Run方式运行](#docker-run方式运行)
-      - [OC](#oc)
-      - [NAC](#nac)
-    - [Docker Compose方式运行](#docker-compose方式运行)
-      - [使用Nginx作为服务器](#使用nginx作为服务器)
-      - [使用Traefik作为服务器](#使用traefik作为服务器)
-  - [升级](#升级)
-  - [有疑问？](#有疑问)
-
 优势
 
-- 基于最新的Cloudreve V3
+- 基于最新的[Cloudreve V3](https://github.com/cloudreve/Cloudreve)
 - 长期维护
 - 镜像体积小
 - 纯净安装，无多余组件
@@ -29,48 +12,21 @@
 - 简易安装
 - 内含详细的Cloudreve+Nginx+Aria2部署教程
 
-## Cloudreve
+## 更新日志
 
-Cloudreve能助您以最低的成本快速搭建公私兼备的网盘系统。
+- `v3.3.2`: 取消了预创建`conf.ini`和`cloudreve.db`过程。在`v3.3.1`版本及以下更新到最新版本之前，请先备份旧版本的`cloudreve.db`文件，在使用新的命令部署之后，将原有的`cloudreve.db`文件拷贝至新的`/cloudreve/db`映射的文件夹中。
 
-官方网站：https://cloudreve.org
+## 获取PUID和PGID
 
-GitHub：https://github.com/cloudreve/Cloudreve
-
-## 开始
-
-运行模式
-
-> ⚠️注意：本教程Nginx配置默认不开启TLS(HTTPS)。如果有相关需求，请将证书保存至Nginx的`ssl`目录并修改Nginx的配置文件。这部分配置工作不在本教程覆盖范围内，因此不会为此提供支持。
-
-### 获取PUID和PGID
-
-为什么要使用PUID和PGID参见: [Understanding PUID and PGID](https://docs.linuxserver.io/general/understanding-puid-and-pgid)
-
-假设当前登陆用户为`root`，则执行
-
-```bash
-id root
-```
-
-就会得到类似于下面的一段代码
+为什么要使用PUID和PGID参见[Understanding PUID and PGID](https://docs.linuxserver.io/general/understanding-puid-and-pgid)。假设当前登陆用户为`root`，则执行`id root`就会得到类似于下面的一段代码：
 
 ```
 uid=1000(root) gid=1001(root)
 ```
 
-则PUID填入1000，PGID填入1001
+则在运行命令中的PUID填入`1000`，PGID填入`1001`。
 
-### Docker Run方式运行
-
-目前有两种运行方式可供选择
-
-- OC模式：仅启动Cloudreve
-- NAC模式：启动Cloudreve，同时使用Nginx作为反向代理服务器以及Aria2作为离线下载服务（可选）
-
-#### OC
-
-启动容器
+## 开始
 
 ```bash
 docker run -d \
@@ -78,7 +34,7 @@ docker run -d \
   -e PUID=1000 \ # optional
   -e PGID=1000 \ # optional
   -e TZ="Asia/Shanghai" \ # optional
-  -p 5212:5212 \ 
+  -p 5212:5212 \
   --restart=unless-stopped \
   -v <PATH TO uploads>:/cloudreve/uploads \
   -v <PATH TO config>:/cloudreve/config \
@@ -93,215 +49,11 @@ docker run -d \
 - PUID以及PGID的获取方式详见`获取PUID和PGID`
 - `TZ`设置时区，默认值为`Asia/Shanghai`
 - `<PATH TO UPLOADS>`:上传目录, 例如`/sharedfolders`
-- `<PATH TO config>`: 配置文件，如`/dockercnf/cloudreve/config`
-- `<PATH TO db`: 数据库文件，如`/dockercnf/cloudreve/db`
+- `<PATH TO config>`: 配置文件夹，如`/dockercnf/cloudreve/config`
+- `<PATH TO db>`: 数据库文件夹，如`/dockercnf/cloudreve/db`
 - `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
 
-#### NAC
-
-> ⚠️注意：此教程仅在linux/amd64架构测试，如果您正在使用arm架构，部分参数请根据实际情况调整。
-
-前提
-
-- 已安装docker，如果没有请执行`wget -qO- https://get.docker.com/ | bash`安装docker。
-- 一个域名并解析到运行Cloudreve的服务器，这里以`cloudreve.example.com`为例。
-
-**Step1. 创建Network**
-
-```bash
-docker network create my-network
-```
-
-**Step2. 创建Nginx配置文件**
-
-```bash
-mkdir -p /dockercnf/nginx/conf.d \
-  && mkdir -p /dockercnf/nginx/ssl \
-	&& vim /dockercnf/nginx/conf.d/cloudreve.conf
-```
-
-填入以下信息
-
-```
-server {
-  listen 80;
-  location / {
-    proxy_pass http://cloudreve:5212;
-    proxy_set_header Host $host;
-  }
-}
-```
-
-**Step3. 启动Nginx服务**
-
-```bash
-docker run -d \
-  --name nginx \
-  -v /dockercnf/nginx/conf.d:/etc/nginx/conf.d \
-  -v /dockercnf/nginx/ssl:/etc/nginx/ssl \
-  --network my-network \
-  -p 80:80 -p 443:443 \
-  --restart unless-stopped \
-  nginx:alpine
-```
-
-**Step4. 启动Aria2服务（如不需要离线下载功能该步骤略过）**
-
-```bash
-docker run -d \
-    --name aria2 \
-    --restart unless-stopped \
-    --log-opt max-size=1m \
-    -e PUID=1000 \
-    -e PGID=1000 \
-    -e RPC_SECRET=<SECRET> \
-    -p 6800:6800 \ #1
-    -p 6888:6888 -p 6888:6888/udp \
-    --network my-network \
-    -v <PATH TO CONFIG>:/config \
-    -v <PATH TO TEMP>:/downloads \
-    p3terx/aria2-pro
-```
-
-说明
-
-- PUID以及PGID的获取方式详见`获取PUID和PGID`。
-- `<SECRET>`: Aria2 RPC密码（你可以去[这里](https://miniwebtool.com/zh-cn/random-string-generator/)生成随机字符串）。请记下该密码！在后续Cloudreve设置Aria2中会使用。
-- `<PATH TO CONFIG>`: Aria2的配置文件夹，例如`/dockercnf/aria2/conf`。
-- `<PATH TO TEMP>`: 临时下载文件夹，需要与Cloudreve的`/downloads`对应，例如`/dockercnf/aria2/temp`。
-- 如果不需要外网访问Aria2可以将`#1`所在行删除。
-
-**Step5. 启动Cloudreve**
-
-```bash
-docker run -d \
-  --name cloudreve \
-  -e PUID=1000 \ # optional
-  -e PGID=1000 \ # optional
-  -e TZ="Asia/Shanghai" \ # optional
-  --network my-network \
-  --restart=unless-stopped \
-  -v <PATH TO UPLOADS>:/cloudreve/uploads \
-  -v <PATH TO TEMP>:/downloads \ #1
-  -v <PATH TO config>:/cloudreve/config \
-  -v <PATH TO db>:/cloudreve/db \
-  -v <PATH TO avatar>:/cloudreve/avatar \
-  xavierniu/cloudreve
-```
-
-说明
-
-- 首次启动后请执行`docker logs -f cloudreve`获取初始密码
-
-- PUID以及PGID的获取方式详见`获取PUID和PGID`
-
-- `<PATH TO UPLOADS>`:上传目录, 例如`/sharedfolders`
-- `<PATH TO TEMP>`: 临时下载文件夹，需要与Aria的`/downloads`对应，例如`/dockercnf/aria2/temp`（如不需要离线下载功能`#1`可以删除）
-- `<PATH TO config>`: 配置文件，如`/dockercnf/cloudreve/config`
-- `<PATH TO db`: 数据库文件，如`/dockercnf/cloudreve/db`
-- `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
-
-**Step6. 配置Cloudreve连接Aria2服务器**
-
-- 以管理员身份登陆
-- 点击"头像（右上角） > 管理面板"
-- 点击"参数设置 > 离线下载"
-
-  - RPC服务器地址: http://aria2:6800/
-  - RPC Secret: 参见`启动Aria2服务`中的`<SECRET>`
-  - 临时下载地址: /downloads
-  - 其他选项按照默认值即可
-- 测试连接并保存
-
-### Docker Compose方式运行
-
-#### 使用Nginx作为服务器
-
-> ⚠️注意：该docker-compose文件仅适用于linux/amd64架构，如果您正在使用arm请尝试修改部分参数。
-
-前提
-
-- 已安装docker，如果没有请执行`wget -qO- https://get.docker.com/ | bash`安装docker。
-- 已安装docker compose，如果没有请参考[Install Docker Compose](https://docs.docker.com/compose/install/)。
-- 一个域名并解析到运行Cloudreve的服务器，这里以`cloudreve.example.com`为例。
-- 确保80和443端口没有被占用，如果您已经有服务器软件（如Nginx或Caddy），请考虑为原有服务器软件增加配置文件并删除docker compose配置文件中的caddy容器。
-
-**Step1. 预创建文件**
-
-Nginx配置文件
-
-```bash
-mkdir -p /dockercnf/nginx/conf.d \
-  && mkdir -p /dockercnf/nginx/ssl \
-	&& vim /dockercnf/nginx/conf.d/cloudreve.conf
-```
-
-填入以下信息
-
-```
-server {
-  listen 80;
-  location / {
-    proxy_pass http://cloudreve:5212;
-    proxy_set_header Host $host;
-  }
-}
-```
-
-**Step2. 下载环境文件以及Docker Compose文件**
-
-下载环境文件
-
-```bash
-wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/docker-compose-env-example > .env
-```
-
-根据需要对环境变量进行修改
-
-- 必填项
-  - CLOUDREVE_PUID: PUID的获取方式详见`获取PUID和PGID`
-  - CLOUDREVE_PGID: PGID的获取方式详见`获取PUID和PGID`
-  - ARIA2_RPC_SECRET: Aria2 RPC密码（你可以去[这里](https://miniwebtool.com/zh-cn/random-string-generator/)生成随机字符串）。请记下该密码！在后续Cloudreve设置Aria2中会使用。
-- 选填项（如无特殊需要不建议修改）
-  - TEMP_FOLDER_PATH: 离线下载临时文件夹路径
-  - ARIA2_CONFIG_PATH: Aria2的配置文件夹路径
-  - CLOUDREVE_UPLOAD_PATH: Cloudreve上传文件夹路径
-  - CLOUDREVE_CONF_INI_PATH: Cloudreve配置文件路径
-  - CLOUDREVE_DB_PATH: Cloudreve数据库文件路径
-
-下载Docker Compose文件
-
-```bash
-wget -qO- https://raw.githubusercontent.com/xavier-niu/cloudreve-docker/master/docker-compose-amd64.yml > docker-compose.yml
-```
-
-**Step3. 启动Docker Compose**
-
-```bash
-docker-compose up -d
-```
-
-说明
-
-- Aria2-RPC会暴露于外网，访问端口`6800`，Secret为你对`ARIA2_RPC_SECRET`设置的随机字符串。
-
-**Step4. 配置Cloudreve连接Aria2服务器**
-
-- 以管理员身份登陆
-- 点击"头像（右上角） > 管理面板"
-- 点击"参数设置 > 离线下载"
-
-  - RPC服务器地址: `http://aria2:6800/`
-  - RPC Secret: 你对`ARIA2_RPC_SECRET`设置的随机字符串
-  - 临时下载地址: `/downloads`
-  - 其他选项按照默认值即可
-- 测试连接并保存
-
-#### 使用Traefik作为服务器
-
-本方案由@expoli提供。Traefik是新一代的Web服务器，支持docker服务发现和自动申请HTTPS证书，只需修改相应的服务的label即可实现服务的反向代理，简化了配置。
-
-相关配置请参阅[https://github.com/expoli/docker-compose-files](https://github.com/expoli/docker-compose-files)，Cloudreve使用**traefik + cloudreve + mysql + redis**实现。
+如果你想使用Nginx作为反向代理服务器，或者使用Aira2作为离线下载服务，请参阅[Cloudreve Docker - NAC](./README-NAC.md)。如果你希望通过docker-compose的方式启动服务，请参阅[Cloudreve Docker - Docker Compose](./README-DOCKER-COMPOSE.md)。
 
 ## 升级
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@
 
 ## 更新日志
 
-- `v3.3.1+`: 取消了预创建`conf.ini`和`cloudreve.db`过程。原则上数据库的迁移工作是无感的，但是依然强烈建议`v3.3.1`及以下版本更新到最新版本之前，先备份旧版本的`cloudreve.db`和`conf.ini`文件（可以通过`docker logs -f cloudreve`查看当前的版本）。
+May 27, 2021: 取消了预创建conf.ini和cloudreve.db过程。原则上数据库的迁移工作是无感的，但是强烈建议**v3.3.1及以下版本**更新到最新版本之前，先备份旧版本的cloudreve.db和conf.ini文件（可以通过`docker logs -f cloudreve`查看当前的版本）。更新完成后，请将cloudreve.db文件复制到`<PATH TO db>`，向conf.ini文件追加数据库路径（如下所示）后复制到`<PATH TO config>`。
+
+```bash
+# conf.ini
+# 向下追加
+[Database]
+DBFile = /cloudreve/db/cloudreve.db
+```
 
 ## 获取PUID和PGID
 
@@ -48,7 +55,7 @@ docker run -d \
 - 首次启动后请执行`docker logs -f cloudreve`获取初始密码
 - PUID以及PGID的获取方式详见`获取PUID和PGID`
 - `TZ`设置时区，默认值为`Asia/Shanghai`
-- `<PATH TO UPLOADS>`:上传目录, 例如`/sharedfolders`
+- `<PATH TO uploads>`:上传目录, 例如`/sharedfolders`
 - `<PATH TO config>`: 配置文件夹，如`/dockercnf/cloudreve/config`
 - `<PATH TO db>`: 数据库文件夹，如`/dockercnf/cloudreve/db`
 - `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker run -d \
 - `<PATH TO db>`: 数据库文件夹，如`/dockercnf/cloudreve/db`
 - `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
 
-如果你想使用Nginx作为反向代理服务器，或者使用Aira2作为离线下载服务，请参阅[Cloudreve Docker - NAC](./README-NAC.md)。如果你希望通过docker-compose的方式启动服务，请参阅[Cloudreve Docker - Docker Compose](./README-DOCKER-COMPOSE.md)。
+如果你想使用Nginx作为反向代理服务器，或者使用Aira2作为离线下载服务，请参阅[Cloudreve Docker - NAC](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-NAC.md)。如果你希望通过docker-compose的方式启动服务，请参阅[Cloudreve Docker - Docker Compose](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-DOCKER-COMPOSE.md)。
 
 ## 升级
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 ![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
+- [Cloudreve Docker](#cloudreve-docker)
+  - [Cloudreve](#cloudreve)
+  - [开始](#开始)
+    - [获取PUID和PGID](#获取puid和pgid)
+    - [Docker Run方式运行](#docker-run方式运行)
+      - [OC](#oc)
+      - [NAC](#nac)
+    - [Docker Compose方式运行](#docker-compose方式运行)
+      - [使用Nginx作为服务器](#使用nginx作为服务器)
+      - [使用Traefik作为服务器](#使用traefik作为服务器)
+  - [升级](#升级)
+  - [有疑问？](#有疑问)
+
 优势
 
 - 基于最新的Cloudreve V3
@@ -24,22 +37,7 @@ GitHub：https://github.com/cloudreve/Cloudreve
 
 运行模式
 
-> ⚠️注意1：由于Caddy v1已停止维护，故支持文档将原有CAC模式变更为NAC模式，即使用Nginx作为反代服务器。目前这项改变尚处于测试阶段，还无法保证NAC模式和Docker Compose方式配置的正确性。如果有任何疑问，请直接提出issue。
-> 
-> ⚠️注意2：本教程Nginx配置默认不开启TLS(HTTPS)。如果有相关需求，请将证书保存至Nginx的`ssl`目录并修改Nginx的配置文件。这部分配置工作不在本教程覆盖范围内，因此不会为此提供支持。
-
-- [Cloudreve Docker](#cloudreve-docker)
-  - [Cloudreve](#cloudreve)
-  - [开始](#开始)
-    - [获取PUID和PGID](#获取puid和pgid)
-    - [Docker Run方式运行](#docker-run方式运行)
-      - [OC](#oc)
-      - [NAC](#nac)
-    - [Docker Compose方式运行](#docker-compose方式运行)
-      - [使用Nginx作为服务器](#使用nginx作为服务器)
-      - [使用Traefik作为服务器](#使用traefik作为服务器)
-  - [升级](#升级)
-  - [有疑问？](#有疑问)
+> ⚠️注意：本教程Nginx配置默认不开启TLS(HTTPS)。如果有相关需求，请将证书保存至Nginx的`ssl`目录并修改Nginx的配置文件。这部分配置工作不在本教程覆盖范围内，因此不会为此提供支持。
 
 ### 获取PUID和PGID
 
@@ -60,6 +58,11 @@ uid=1000(root) gid=1001(root)
 则PUID填入1000，PGID填入1001
 
 ### Docker Run方式运行
+
+目前有两种运行方式可供选择
+
+- OC模式：仅启动Cloudreve
+- NAC模式：启动Cloudreve，同时使用Nginx作为反向代理服务器以及Aria2作为离线下载服务（可选）
 
 #### OC
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
+> 请注意：最新版本中取消了预创建`conf.ini`和`cloudreve.db`过程，所以需要更新容器运行命令，老版本运行命令最大支持版本为`v3.3.1`。
+
 - [Cloudreve Docker](#cloudreve-docker)
   - [Cloudreve](#cloudreve)
   - [开始](#开始)
@@ -66,14 +68,6 @@ uid=1000(root) gid=1001(root)
 
 #### OC
 
-预创建Cloudreve的数据库和配置文件，这里以`/dockercnf/cloudreve`为cloudreve配置目录。
-
-```bash
-mkdir -p /dockercnf/cloudreve \
-	&& touch /dockercnf/cloudreve/conf.ini \
-	&& touch /dockercnf/cloudreve/cloudreve.db
-```
-
 启动容器
 
 ```bash
@@ -84,9 +78,9 @@ docker run -d \
   -e TZ="Asia/Shanghai" \ # optional
   -p 5212:5212 \ 
   --restart=unless-stopped \
-  -v <PATH TO UPLOADS>:/cloudreve/uploads \
-  -v <PATH TO conf.ini>:/cloudreve/conf.ini \
-  -v <PATH TO cloudreve.db>:/cloudreve/cloudreve.db \
+  -v <PATH TO uploads>:/cloudreve/uploads \
+  -v <PATH TO config>:/cloudreve/config \
+  -v <PATH TO db>:/cloudreve/db \
   -v <PATH TO avatar>:/cloudreve/avatar \
   xavierniu/cloudreve
 ```
@@ -97,9 +91,9 @@ docker run -d \
 - PUID以及PGID的获取方式详见`获取PUID和PGID`
 - `TZ`设置时区，默认值为`Asia/Shanghai`
 - `<PATH TO UPLOADS>`:上传目录, 例如`/sharedfolders`
-- `<PATH TO conf.ini>`: 配置文件，如`/dockercnf/cloudreve/conf.ini`（注意这里是挂载的文件，而非文件夹）
-- ` <PATH TO cloudreve.db>`: 数据库文件，如`/dockercnf/cloudreve/cloudreve.db`（注意这里是挂载的文件，而非文件夹）
-- ` <PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
+- `<PATH TO config>`: 配置文件，如`/dockercnf/cloudreve/config`
+- `<PATH TO db`: 数据库文件，如`/dockercnf/cloudreve/db`
+- `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
 
 #### NAC
 
@@ -175,15 +169,7 @@ docker run -d \
 - `<PATH TO TEMP>`: 临时下载文件夹，需要与Cloudreve的`/downloads`对应，例如`/dockercnf/aria2/temp`。
 - 如果不需要外网访问Aria2可以将`#1`所在行删除。
 
-**Step5. 预创建Cloudreve的数据库和配置文件，这里以`/dockercnf/cloudreve`为cloudreve配置目录**
-
-```bash
-mkdir -p /dockercnf/cloudreve \
-	&& touch /dockercnf/cloudreve/conf.ini \
-	&& touch /dockercnf/cloudreve/cloudreve.db
-```
-
-**Step6. 启动Cloudreve**
+**Step5. 启动Cloudreve**
 
 ```bash
 docker run -d \
@@ -195,9 +181,9 @@ docker run -d \
   --restart=unless-stopped \
   -v <PATH TO UPLOADS>:/cloudreve/uploads \
   -v <PATH TO TEMP>:/downloads \ #1
-  -v <PATH TO conf.ini>:/cloudreve/conf.ini \
-  -v <PATH TO cloudreve.db>:/cloudreve/cloudreve.db \
-  -v <PATH TO avatar>:/cloudreve/avatar \ 
+  -v <PATH TO config>:/cloudreve/config \
+  -v <PATH TO db>:/cloudreve/db \
+  -v <PATH TO avatar>:/cloudreve/avatar \
   xavierniu/cloudreve
 ```
 
@@ -209,11 +195,11 @@ docker run -d \
 
 - `<PATH TO UPLOADS>`:上传目录, 例如`/sharedfolders`
 - `<PATH TO TEMP>`: 临时下载文件夹，需要与Aria的`/downloads`对应，例如`/dockercnf/aria2/temp`（如不需要离线下载功能`#1`可以删除）
-- `<PATH TO conf.ini>`: 配置文件，如`/dockercnf/cloudreve/conf.ini`
-- ` <PATH TO cloudreve.db>`: 数据库文件，如`/dockercnf/cloudreve/cloudreve.db`
-- ` <PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
+- `<PATH TO config>`: 配置文件，如`/dockercnf/cloudreve/config`
+- `<PATH TO db`: 数据库文件，如`/dockercnf/cloudreve/db`
+- `<PATH TO avatar>`: 头像文件夹，如`/dockercnf/cloudreve/avatar`
 
-**Step7. 配置Cloudreve连接Aria2服务器**
+**Step6. 配置Cloudreve连接Aria2服务器**
 
 - 以管理员身份登陆
 - 点击"头像（右上角） > 管理面板"
@@ -258,14 +244,6 @@ server {
     proxy_set_header Host $host;
   }
 }
-```
-
-Cloudreve配置文件及数据库文件
-
-```bash
-mkdir -p /dockercnf/cloudreve \
-	&& touch /dockercnf/cloudreve/conf.ini \
-	&& touch /dockercnf/cloudreve/cloudreve.db
 ```
 
 **Step2. 下载环境文件以及Docker Compose文件**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
-> [!!!!]版本低于`v3.3.1`的更新提示：
+> [重要‼️]版本低于或等于`v3.3.1`的更新提示：
 > 
 > 最新版本中取消了预创建`conf.ini`和`cloudreve.db`过程，因此版本更新牵扯到数据库的路径更新。在更新到最新版本之前请备份旧版本的`cloudreve.db`文件，在使用新的命令运行之后，需要将原有的`cloudreve.db`文件拷贝至新的`/cloudreve/db`映射的文件夹中。
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
-> 请注意：最新版本中取消了预创建`conf.ini`和`cloudreve.db`过程，所以需要更新容器运行命令，老版本运行命令最大支持版本为`v3.3.1`。
+> [!!!!]版本低于`v3.3.1`的更新提示：
+> 
+> 最新版本中取消了预创建`conf.ini`和`cloudreve.db`过程，因此版本更新牵扯到数据库的路径更新。在更新到最新版本之前请备份旧版本的`cloudreve.db`文件，在使用新的命令运行之后，需要将原有的`cloudreve.db`文件拷贝至新的`/cloudreve/db`映射的文件夹中。
 
 - [Cloudreve Docker](#cloudreve-docker)
   - [Cloudreve](#cloudreve)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloudreve Docker
 
-![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.1-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
+![](https://img.shields.io/github/workflow/status/xavier-niu/cloudreve-docker/Publish%20Docker) ![](https://img.shields.io/badge/cloudreve-3.3.2-brightgreen) ![](https://img.shields.io/docker/image-size/xavierniu/cloudreve/latest) ![](https://img.shields.io/docker/pulls/xavierniu/cloudreve) ![](https://img.shields.io/badge/maintainer-xavierniu-lightgrey)
 
 优势
 
@@ -14,7 +14,7 @@
 
 ## 更新日志
 
-May 27, 2021: [⚠️⚠️⚠️]取消了预创建conf.ini和cloudreve.db过程。原则上数据库的迁移工作是无感的，但是强烈建议**v3.3.1及以下版本**更新到最新版本之前，先备份旧版本的cloudreve.db和conf.ini文件（可以通过`docker logs -f cloudreve`查看当前的版本）。更新完成后，请将cloudreve.db文件复制到`<PATH TO db>`，向conf.ini文件追加数据库路径（如下所示）后复制到`<PATH TO config>`。
+- v3.3.2(May 27, 2021): [**⚠️请注意**]取消了预创建conf.ini和cloudreve.db过程。原则上数据库的迁移工作是无感的，但是强烈建议**v3.3.1及以下版本**更新到最新版本之前，先备份旧版本的cloudreve.db和conf.ini文件（可以通过`docker logs -f cloudreve`查看当前的版本）。更新完成后，请将cloudreve.db文件复制到`<PATH TO db>`，向conf.ini文件追加数据库路径（如下所示）后复制到`<PATH TO config>`。
 
 ```bash
 # conf.ini

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 更新日志
 
-- `v3.3.2`: 取消了预创建`conf.ini`和`cloudreve.db`过程。在`v3.3.1`版本及以下更新到最新版本之前，请先备份旧版本的`cloudreve.db`文件，在使用新的命令部署之后，将原有的`cloudreve.db`文件拷贝至新的`/cloudreve/db`映射的文件夹中。
+- `v3.3.1+`: 取消了预创建`conf.ini`和`cloudreve.db`过程。原则上数据库的迁移工作是无感的，但是依然强烈建议`v3.3.1`及以下版本更新到最新版本之前，先备份旧版本的`cloudreve.db`和`conf.ini`文件（可以通过`docker logs -f cloudreve`查看当前的版本）。
 
 ## 获取PUID和PGID
 

--- a/conf.ini
+++ b/conf.ini
@@ -1,0 +1,2 @@
+[Database]
+DBFile = /cloudreve/db/cloudreve.db

--- a/conf.ini
+++ b/conf.ini
@@ -1,2 +1,0 @@
-[Database]
-DBFile = /cloudreve/db/cloudreve.db

--- a/docker-compose-amd64.yml
+++ b/docker-compose-amd64.yml
@@ -41,8 +41,8 @@ services:
         volumes: 
             - ${CLOUDREVE_UPLOAD_PATH}:/cloudreve/uploads
             - ${TEMP_FOLDER_PATH}:/downloads
-            - ${CLOUDREVE_CONF_INI_PATH}:/cloudreve/conf.ini
-            - ${CLOUDREVE_DB_PATH}:/cloudreve/cloudreve.db
+            - ${CLOUDREVE_CONF_PATH}:/cloudreve/config
+            - ${CLOUDREVE_DB_PATH}:/cloudreve/db
             - ${CLOUDREVE_AVATAR_PATH}:/cloudreve/avatar
         networks: 
             - cloudreve-network

--- a/docker-compose-env-example
+++ b/docker-compose-env-example
@@ -19,6 +19,6 @@ ARIA2_CONFIG_PATH=/dockercnf/aria2/conf
 
 # > Cloudreve
 CLOUDREVE_UPLOAD_PATH=/sharedfolders
-CLOUDREVE_CONF_INI_PATH=/dockercnf/cloudreve/conf.ini
-CLOUDREVE_DB_PATH=/dockercnf/cloudreve/cloudreve.db
+CLOUDREVE_CONF_PATH=/dockercnf/cloudreve/config
+CLOUDREVE_DB_PATH=/dockercnf/cloudreve/db
 CLOUDREVE_AVATAR_PATH=/dockercnf/cloudreve/avatar

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-chmod +x ./cloudreve-main
-
 # database
 CLOUDREVE_DEFAULT_DB=cloudreve.db
 CLOUDREVE_DB=db/cloudreve.db
@@ -17,7 +15,7 @@ if [ ! -e $CLOUDREVE_DB ]; then
         mv $CLOUDREVE_DEFAULT_CONF $CLOUDREVE_CONF
     fi
     if [ ! e $CLOUDREVE_DEFAULT_DB ]; then
-        nohup ./cloudreve-main -c $CLOUDREVE_CONF > $CLOUDREVE_INIT_LOG 2>&1 &
+        nohup cloudreve -c $CLOUDREVE_CONF > $CLOUDREVE_INIT_LOG 2>&1 &
         echo "Waiting Cloudreve initializing..."
         sleep 5
         kill -9 $(ps -ef | grep cloudreve-main | grep -v grep | awk {'print $2'})
@@ -28,5 +26,5 @@ if [ ! -e $CLOUDREVE_DB ]; then
     echo -e "[Database]\nDBFile=$CLOUDREVE_DB" >> $CLOUDREVE_CONF
 fi
 
-./cloudreve-main -c $CLOUDREVE_CONF
+cloudreve -c $CLOUDREVE_CONF
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 chmod +x ./cloudreve-main
-./cloudreve-main -c /cloudreve/conf.ini
+./cloudreve-main -c config/conf.ini -d db/cloudreve.db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
 
 chmod +x ./cloudreve-main
-./cloudreve-main -c config/conf.ini
+
+CLOUDREVE_DEFAULT_DB=cloudreve.db
+CLOUDREVE_DB=db/cloudreve.db
+CLOUDREVE_CONF=config/conf.ini
+CLOUDREVE_INIT_LOG=init.log
+
+if [ ! -e $CLOUDREVE_DB ]; then
+    if [ ! e $CLOUDREVE_DEFAULT_DB ]; then
+        nohup ./cloudreve-main -c $CLOUDREVE_CONF > $CLOUDREVE_INIT_LOG 2>&1 &
+        echo "Waiting Cloudreve initializing..."
+        sleep 5
+        kill -9 $(ps -ef | grep cloudreve-main | grep -v grep | awk {'print $2'})
+        cat $CLOUDREVE_INIT_LOG
+        rm -f $CLOUDREVE_INIT_LOG
+    fi
+    mv $CLOUDREVE_DEFAULT_DB $CLOUDREVE_DB
+    echo -e "[Database]\nDBFile=$CLOUDREVE_DB" >> $CLOUDREVE_CONF
+fi
+
+./cloudreve-main -c $CLOUDREVE_CONF
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,12 +2,20 @@
 
 chmod +x ./cloudreve-main
 
+# database
 CLOUDREVE_DEFAULT_DB=cloudreve.db
 CLOUDREVE_DB=db/cloudreve.db
+# conf
+CLOUDREVE_DEFAULT_CONF=conf.ini
 CLOUDREVE_CONF=config/conf.ini
+# init log
 CLOUDREVE_INIT_LOG=init.log
 
 if [ ! -e $CLOUDREVE_DB ]; then
+    if [ -e CLOUDREVE_DEFAULT_CONF ]; then
+        echo "Found conf at `$CLOUDREVE_DEFAULT_CONF`, it has been moved to `$CLOUDREVE_CONF`"
+        mv $CLOUDREVE_DEFAULT_CONF $CLOUDREVE_CONF
+    fi
     if [ ! e $CLOUDREVE_DEFAULT_DB ]; then
         nohup ./cloudreve-main -c $CLOUDREVE_CONF > $CLOUDREVE_INIT_LOG 2>&1 &
         echo "Waiting Cloudreve initializing..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 chmod +x ./cloudreve-main
-./cloudreve-main -c config/conf.ini -d db/cloudreve.db
+./cloudreve-main -c config/conf.ini


### PR DESCRIPTION
- Fix problem of pre-allocated files(#39)
- Split READMEs and update their styles
- Move `cloudreve_main` to `$PATH`(#41)
- Remove modifying authority for `cloudreve_main` from `entrypoint.sh`(#41)