### PR TITLE
让用户以更快速度运行 Cloudreve？

### DIFF
--- a/READEME-TEAMCODE.md
+++ b/READEME-TEAMCODE.md
@@ -1,0 +1,41 @@
+TeamCode Tin已将Cloudreve所需的云端运行环境打包成容器，用户点击即可直接在云端运行Cloudreve项目，从而完全跳过安装配置过程。
+
+用户操作步骤：
+
+1.点击README中的Tin按钮（如下图），该按钮为Cloudreve Tin应用的访问网址。
+
+![img](https://static01.teamcode.com/docs/202112201843912.png)
+
+2.点击按钮后，进入TeamCode登录页面（已登录用户可跳过该步骤）。
+
+![img](https://static01.teamcode.com/docs/202112201843463.png)
+
+3.完成登录后，进入Tin应用页面。
+
+![img](https://static01.teamcode.com/docs/202112201843272.png)
+
+4.点击 Clone，像fork github项目一样，将Cloudreve项目克隆到自己的Tin工作空间。
+
+![img](https://static01.teamcode.com/docs/202112201843030.png)
+
+（如上图显示克隆成功）
+
+5.点击 RUN NOW，Tin应用会立即运行。
+
+![img](https://static01.teamcode.com/docs/202112201843160.png)
+
+6.点击Endpoint Lists，可以看到访问Cloudreve的入口。
+
+![img](https://static01.teamcode.com/docs/202112201843049.png)
+
+7.点击图中红框的链接，即可立即访问Cloudreve。
+
+![img](https://static01.teamcode.com/docs/202112201844192.png)
+
+注册/登录后即可使用。
+
+
+
+注册TeamCode的用户，每个月都有免费计划可以使用。
+
+![img](https://static01.teamcode.com/docs/202112201844339.png)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ uid=1000(root) gid=1001(root)
 
 ## 开始
 
-无安装运行 [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=270604044600766464)
-
 目录
 
 - `<PATH TO uploads>`:上传目录，如 `/sharedfolders`
@@ -72,6 +70,7 @@ docker run -d \
 
 其他教程
 
+- 如果您想远程云端启动服务，请参阅 [Run In Cloud](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-TEAMCODE.md)；
 - 如果你想使用 Nginx 作为反向代理服务器，或者使用 Aira2 作为离线下载服务，请参阅 [Cloudreve Docker - NAC](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-NAC.md)；
 - 如果你希望通过 docker-compose 的方式启动服务，请参阅 [Cloudreve Docker - Docker Compose](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-DOCKER-COMPOSE.md)。
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ docker run -d \
 
 其他教程
 
-- 如果您想远程云端启动服务，请参阅 [Run In Cloud](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-TEAMCODE.md)；
 - 如果你想使用 Nginx 作为反向代理服务器，或者使用 Aira2 作为离线下载服务，请参阅 [Cloudreve Docker - NAC](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-NAC.md)；
 - 如果你希望通过 docker-compose 的方式启动服务，请参阅 [Cloudreve Docker - Docker Compose](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-DOCKER-COMPOSE.md)。
+- 如果您想远程云端启动服务，请参阅 [Run In Cloud](https://github.com/xavier-niu/cloudreve-docker/blob/master/README-TEAMCODE.md) 【每月免费使用时间有限制，超过则需支付费用】；
 
 ## 升级
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ uid=1000(root) gid=1001(root)
 
 ## 开始
 
+无安装运行 [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=270604044600766464)
+
 目录
 
 - `<PATH TO uploads>`:上传目录，如 `/sharedfolders`


### PR DESCRIPTION
用户可以借助链接快速建立 Cloudreve 实例，或许能节约用户的时间。

注：每个注册用户每个月都有免费使用时长

[构建链接](https://www.teamcode.com/tin/clone?applicationId=270604044600766464)  和  [构建文档](https://www.teamcode.com/docs/en-US/tin/clone-tin)