### PR TITLE
Update README-NAC.md

### DIFF
--- a/README-NAC.md
+++ b/README-NAC.md
@@ -53,6 +53,7 @@ docker run -d \
     --name aria2 \
     --restart unless-stopped \
     --log-opt max-size=1m \
+    --log-driver json-file \
     -e PUID=1000 \
     -e PGID=1000 \
     -e RPC_SECRET=<SECRET> \


### PR DESCRIPTION
解决文档中的如下问题：
Docker version: 1.13.1 下，run aria2 报错： /usr/bin/docker-current: Error response from daemon: unknown log opt 'max-size' for journald log driver.

增加参数：--log-driver json-file

