### PR TITLE
编译时有个三方库需要1.17.1的golang。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.17.1-alpine as builder
 
 ARG CLOUDREVE_VERSION="3.5.0"
 


### PR DESCRIPTION
<!-- required -->
**What does this pr do?**

- Upgrade golang to 1.17.1

<!-- required -->
**Which issue is fixed by this pr?** 

- Fixes # `error hapened when compile cloudreve 3.5.0. `

<!-- optional, if none, please leave a "NONE" at below -->
**Does have any extra information?**

- None

